### PR TITLE
Add screen size for ID5 non XL Mini

### DIFF
--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/RHMIDimensions.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/RHMIDimensions.kt
@@ -48,10 +48,7 @@ class SubsetRHMIDimensions(override val rhmiWidth: Int, override val rhmiHeight:
 	override val paddingTop: Int = 0
 	override val marginRight: Int = 0
 }
-class Mini5Dimensions: MiniDimensions(980, 540) {
-	override val marginLeft: Int = 0
-	override val paddingLeft: Int = 170
-}
+
 class GenericRHMIDimensions(override val rhmiWidth: Int, override val rhmiHeight: Int): RHMIDimensions {
 	/*
 	@jezikk82 calculated the following sizes
@@ -98,8 +95,10 @@ class Mini5XLDimensions: MiniDimensions(1440, 540) {
 	override val marginLeft: Int = 0
 	override val paddingLeft: Int = 168     // so we can remove all of the padding
 }
-
-/**
+class Mini5Dimensions: MiniDimensions(980, 540) {
+	override val marginLeft: Int = 0
+	override val paddingLeft: Int = 170
+}
  * Wraps an existing RHMIDimensions to toggle the marginRight based on an open sidebar
  */
 class SidebarRHMIDimensions(val fullscreen: RHMIDimensions, val isWidescreen: () -> Boolean): RHMIDimensions {

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/RHMIDimensions.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/RHMIDimensions.kt
@@ -95,10 +95,12 @@ class Mini5XLDimensions: MiniDimensions(1440, 540) {
 	override val marginLeft: Int = 0
 	override val paddingLeft: Int = 168     // so we can remove all of the padding
 }
+
 class Mini5Dimensions: MiniDimensions(980, 540) {
 	override val marginLeft: Int = 0
 	override val paddingLeft: Int = 170
 }
+
  * Wraps an existing RHMIDimensions to toggle the marginRight based on an open sidebar
  */
 class SidebarRHMIDimensions(val fullscreen: RHMIDimensions, val isWidescreen: () -> Boolean): RHMIDimensions {

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/RHMIDimensions.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/RHMIDimensions.kt
@@ -31,6 +31,7 @@ interface RHMIDimensions {
 
 			if (brand == "BMW" && !id4 && rhmiWidth == 1440) return BMW5XLRHMIDimensions(rhmiWidth, rhmiHeight)
 			if (brand == "MINI" && !id4 && a4axl) return Mini5XLDimensions()
+			if (brand == "MINI" && !id4) return Mini5Dimensions()
 			if (brand == "MINI") return MiniDimensions(rhmiWidth, rhmiHeight)
 			return GenericRHMIDimensions(rhmiWidth, rhmiHeight)
 		}
@@ -47,7 +48,10 @@ class SubsetRHMIDimensions(override val rhmiWidth: Int, override val rhmiHeight:
 	override val paddingTop: Int = 0
 	override val marginRight: Int = 0
 }
-
+class Mini5Dimensions: MiniDimensions(980, 540) {
+	override val marginLeft: Int = 0
+	override val paddingLeft: Int = 170
+}
 class GenericRHMIDimensions(override val rhmiWidth: Int, override val rhmiHeight: Int): RHMIDimensions {
 	/*
 	@jezikk82 calculated the following sizes

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/RHMIDimensions.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/RHMIDimensions.kt
@@ -100,7 +100,7 @@ class Mini5Dimensions: MiniDimensions(980, 540) {
 	override val marginLeft: Int = 0
 	override val paddingLeft: Int = 170
 }
-
+/**
  * Wraps an existing RHMIDimensions to toggle the marginRight based on an open sidebar
  */
 class SidebarRHMIDimensions(val fullscreen: RHMIDimensions, val isWidescreen: () -> Boolean): RHMIDimensions {


### PR DESCRIPTION
Previously, only ID4 and ID5XL displays were properly optimized, resulting in weird size for the non XL ID5 touchscreen. This adds ID5 non XL dimensions so it properly fits the screen. Some of the corners are clipped off the screen to ensure that it reach's edge to edge.