### PR TITLE
Fix missing icon for several apps

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,9 @@
     <uses-permission android:name="android.permission.READ_SMS" />
     <!-- Open Assistant while the screen is off in new phones -->
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+    <!-- Retrieve package information (app icon, etc.) from all apps -->
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
+        tools:ignore="QueryAllPackagesPermission" />
     <!-- View Bluetooth status -->
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <!-- But don't require Bluetooth support -->

--- a/app/src/play/AndroidManifest.xml
+++ b/app/src/play/AndroidManifest.xml
@@ -8,7 +8,7 @@
 	
 	<!-- Google Play doesn't allow QUERY_ALL_PACKAGES -->
 	<!-- https://support.google.com/googleplay/android-developer/answer/10158779?hl=en -->
-    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" tools:node="remove" />
 
     <application>
     </application>

--- a/app/src/play/AndroidManifest.xml
+++ b/app/src/play/AndroidManifest.xml
@@ -5,6 +5,10 @@
 
     <!-- Google Play doesn't allow READ_SMS -->
     <uses-permission android:name="android.permission.READ_SMS" tools:node="remove" />
+	
+	<!-- Google Play doesn't allow QUERY_ALL_PACKAGES -->
+	<!-- https://support.google.com/googleplay/android-developer/answer/10158779?hl=en -->
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
 
     <application>
     </application>


### PR DESCRIPTION
Fixes #456 

Since Android 11 it's necessary to maintain package visibility for every app to retrieve their package info.
See here: https://medium.com/androiddevelopers/package-visibility-in-android-11-cc857f221cd9

To not include every app, we will use QUERY_ALL_PACKAGES permission. With this permission AAIdrive can retrieve package infos for every app. Sadly this is not accepted by the play store policies. Due that we will remove the permission for play store builds. 
So the issue is only fixed for NONE playstore builds. 
Maybe we will get some more info about this issue later here:
https://stackoverflow.com/questions/69901436/how-can-a-notificationlistenerservice-use-getapplicationinfo-on-android-11-api