### PR TITLE
Spotify large playlist fix

### DIFF
--- a/app/src/main/java/me/hufman/androidautoidrive/music/controllers/SpotifyAppController.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/music/controllers/SpotifyAppController.kt
@@ -182,7 +182,6 @@ class SpotifyAppController(context: Context, val remote: SpotifyAppRemote, val w
 	var position: PlaybackPosition = PlaybackPosition(true, false, 0, 0, -1)
 	var currentTrackLibrary: Boolean? = null
 	var currentPlayerContext: PlayerContext = PlayerContext()
-	var queueItems: List<MusicMetadata> = LinkedList()
 	var queueMetadata: QueueMetadata? = null
 	val coverArtCache = LruCache<ImageUri, Bitmap>(50)
 	var createQueueMetadataJob: Job? = null
@@ -245,7 +244,6 @@ class SpotifyAppController(context: Context, val remote: SpotifyAppRemote, val w
 			val uri = playerContext.uri
 			if (currentPlayerContext.uri != uri) {
 				currentPlayerContext = playerContext
-				queueItems = emptyList()
 
 				// if there are any running QueueMetadata creation jobs then stop those
 				if (createQueueMetadataJob?.isActive == true) {
@@ -290,11 +288,11 @@ class SpotifyAppController(context: Context, val remote: SpotifyAppRemote, val w
 				currentPlayerContext.uri
 			}
 
-			queueItems = webApi.getArtistTopSongs(this@SpotifyAppController, artistUri) ?: emptyList()
+			val queueItems = webApi.getArtistTopSongs(this@SpotifyAppController, artistUri) ?: emptyList()
 			if (queueItems.isNotEmpty()) {
 				if (temporaryPlaylistState != null) {
 					Log.d(TAG, "Previous artist state found and loaded for artist ${currentPlayerContext.title}")
-					temporaryPlaylistState = loadAndUpdateTemporaryPlaylistState(artistSongsStateJson)
+					temporaryPlaylistState = loadAndUpdateTemporaryPlaylistState(artistSongsStateJson, queueItems)
 				} else {
 					// PlayerContext title of an artist playlist is sometimes blank
 					if (currentPlayerContext.title.isBlank()) {
@@ -303,15 +301,14 @@ class SpotifyAppController(context: Context, val remote: SpotifyAppRemote, val w
 
 					temporaryPlaylistState = if (artistSongsStateJson.isBlank()) {
 						Log.d(TAG, "No previous artist state found for artist ${currentPlayerContext.title}")
-						createTemporaryPlaylistState(SpotifyWebApi.ARTIST_SONGS_PLAYLIST_NAME)
+						createTemporaryPlaylistState(SpotifyWebApi.ARTIST_SONGS_PLAYLIST_NAME, queueItems)
 					} else {
 						Log.d(TAG, "Found previous artist state for artist ${currentPlayerContext.title}")
-						loadAndUpdateTemporaryPlaylistState(artistSongsStateJson)
+						loadAndUpdateTemporaryPlaylistState(artistSongsStateJson, queueItems)
 					}
 
 					if (temporaryPlaylistState == null) {
 						Log.e(TAG, "Error creating artist songs playlist for artist ${currentPlayerContext.title}, falling back to app remote API")
-						queueItems = emptyList()
 						createPlaylistQueueMetadata(currentPlayerContext, false)
 						return@launch
 					}
@@ -332,8 +329,7 @@ class SpotifyAppController(context: Context, val remote: SpotifyAppRemote, val w
 	 */
 	fun createLikedSongsQueueMetadata() {
 		createQueueMetadataJob = GlobalScope.launch(defaultDispatcher) {
-			queueItems = webApi.getLikedSongs(this@SpotifyAppController) ?: emptyList()
-
+			val queueItems = webApi.getLikedSongs(this@SpotifyAppController) ?: emptyList()
 			if (queueItems.isNotEmpty()) {
 				queueMetadata = QueueMetadata(currentPlayerContext.title, null, queueItems)
 				onQueueLoaded?.invoke()
@@ -343,14 +339,13 @@ class SpotifyAppController(context: Context, val remote: SpotifyAppRemote, val w
 
 				val temporaryPlaylistState = if (likedSongsStateJson.isBlank()) {
 					Log.d(TAG, "No previous liked songs state found.")
-					createTemporaryPlaylistState(SpotifyWebApi.LIKED_SONGS_PLAYLIST_NAME)
+					createTemporaryPlaylistState(SpotifyWebApi.LIKED_SONGS_PLAYLIST_NAME, queueItems)
 				} else {
 					Log.d(TAG, "Found previous liked songs state.")
-					loadAndUpdateTemporaryPlaylistState(likedSongsStateJson)
+					loadAndUpdateTemporaryPlaylistState(likedSongsStateJson, queueItems)
 				}
 				if (temporaryPlaylistState == null) {
 					Log.e(TAG, "Error creating liked songs playlist, falling back to app remote API")
-					queueItems = emptyList()
 					createPlaylistQueueMetadata(currentPlayerContext, false)
 					return@launch
 				}
@@ -369,7 +364,7 @@ class SpotifyAppController(context: Context, val remote: SpotifyAppRemote, val w
 	 * is not present and adding the queueItems in context to it. If the playlist creation fails
 	 * then null is returned.
 	 */
-	private suspend fun createTemporaryPlaylistState(playlistName: String): TemporaryPlaylistState? {
+	private suspend fun createTemporaryPlaylistState(playlistName: String, queueItems: List<MusicMetadata>): TemporaryPlaylistState? {
 		val queueItemsHashCode = queueItems.hashCode().toString()
 		val existingPlaylistUri = webApi.getPlaylistUri(playlistName)
 		val playlistUri: String
@@ -405,7 +400,7 @@ class SpotifyAppController(context: Context, val remote: SpotifyAppRemote, val w
 	 * deserialized [TemporaryPlaylistState] is not valid then its contents and hash code will be
 	 * updated.
 	 */
-	private suspend fun loadAndUpdateTemporaryPlaylistState(temporaryPlaylistStateJson: String): TemporaryPlaylistState {
+	private suspend fun loadAndUpdateTemporaryPlaylistState(temporaryPlaylistStateJson: String, queueItems: List<MusicMetadata>): TemporaryPlaylistState {
 		val queueItemsHashCode = queueItems.hashCode().toString()
 		val temporaryPlaylistState = gson.fromJson(temporaryPlaylistStateJson, TemporaryPlaylistState::class.java)
 
@@ -459,12 +454,12 @@ class SpotifyAppController(context: Context, val remote: SpotifyAppRemote, val w
 	 */
 	private fun createPlaylistQueueMetadata(playerContext: PlayerContext, useWebApi: Boolean) {
 		createQueueMetadataJob = GlobalScope.launch(defaultDispatcher) {
-			if (currentPlayerContext.uri != null && queueItems.isEmpty()) {
+			if (currentPlayerContext.uri != null) {
 				currentPlayerContext = playerContext
 				if (useWebApi) {
-					queueItems = webApi.getPlaylistSongs(this@SpotifyAppController, playerContext.uri) ?: emptyList()
+					val queueItems = webApi.getPlaylistSongs(this@SpotifyAppController, playerContext.uri) ?: emptyList()
 					if (queueItems.isNotEmpty()) {
-						createQueueMetadataFromPlayerContext(playerContext)
+						createQueueMetadataFromPlayerContext(playerContext, queueItems)
 					} else {
 						Log.e(TAG, "Error getting songs from playlist ${playerContext.uri}, falling back to app remote API")
 						createQueueMetadataWithAppRemote(playerContext)
@@ -481,7 +476,7 @@ class SpotifyAppController(context: Context, val remote: SpotifyAppRemote, val w
 	 */
 	private fun createPodcastQueueMetadata(playerContext: PlayerContext) {
 		createQueueMetadataJob = GlobalScope.launch(defaultDispatcher) {
-			if (currentPlayerContext.uri != null && queueItems.isEmpty()) {
+			if (currentPlayerContext.uri != null) {
 				createQueueMetadataWithAppRemote(playerContext)
 			}
 		}
@@ -493,15 +488,15 @@ class SpotifyAppController(context: Context, val remote: SpotifyAppRemote, val w
 	private fun createQueueMetadataWithAppRemote(playerContext: PlayerContext) {
 		val listItem = ListItem(playerContext.uri, playerContext.uri, null, playerContext.title, playerContext.subtitle, false, true)
 		loadPaginatedItems(listItem, { currentPlayerContext.uri == playerContext.uri }) {
-			queueItems = removeShufflePlayButtonMetadata(it, currentPlayerContext.uri)
-			createQueueMetadataFromPlayerContext(playerContext)
+			val queueItems = removeShufflePlayButtonMetadata(it, currentPlayerContext.uri)
+			createQueueMetadataFromPlayerContext(playerContext, queueItems)
 		}
 	}
 
 	/**
 	 * Creates the [QueueMetadata] for the provided [PlayerContext].
 	 */
-	private fun createQueueMetadataFromPlayerContext(playerContext: PlayerContext) {
+	private fun createQueueMetadataFromPlayerContext(playerContext: PlayerContext, queueItems: List<MusicMetadata>) {
 		// builds the QueueMetadata while waiting for cover art to load
 		queueMetadata = QueueMetadata(playerContext.title, playerContext.subtitle, queueItems, mediaId = playerContext.uri)
 		currentPlayerContext = PlayerContext(playerContext.uri, playerContext.title, playerContext.subtitle, playerContext.type)
@@ -626,7 +621,7 @@ class SpotifyAppController(context: Context, val remote: SpotifyAppRemote, val w
 		// so, we have to iterate through the queue to find the user's selected queueId
 		val queueUri = this.currentPlayerContext.uri
 		if (song.queueId != null) {
-			queueItems.forEachIndexed { index, it ->
+			queueMetadata?.songs?.forEachIndexed { index, it ->
 				if (it.queueId == song.queueId) {
 					remote.playerApi.skipToIndex(queueUri, index)
 					return

--- a/app/src/main/java/me/hufman/androidautoidrive/music/controllers/SpotifyAppController.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/music/controllers/SpotifyAppController.kt
@@ -454,8 +454,8 @@ class SpotifyAppController(context: Context, val remote: SpotifyAppRemote, val w
 
 	/**
 	 * Creates the [QueueMetadata] for the playlist either using the Web API or App Remote API. If
-	 * the Web API is not authorized but chosen then the [QueueMetadata] falls back to the App Remote
-	 * API to create the [QueueMetadata].
+	 * the Web API is marked to be used but is not authorized, the App Remote API is used as a fallback
+	 * to create the [QueueMetadata].
 	 */
 	private fun createPlaylistQueueMetadata(playerContext: PlayerContext, useWebApi: Boolean) {
 		createQueueMetadataJob = GlobalScope.launch(defaultDispatcher) {

--- a/app/src/main/java/me/hufman/androidautoidrive/music/spotify/SpotifyWebApi.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/music/spotify/SpotifyWebApi.kt
@@ -71,7 +71,7 @@ class SpotifyWebApi private constructor(val context: Context, val appSettings: M
 
 	/**
 	 * Returns the songs from a specified playlist URI. This supports playlists that include both
-	 * songs and podcasts.
+	 * songs and podcasts. Local tracks are not supported.
 	 */
 	suspend fun getPlaylistSongs(spotifyAppController: SpotifyAppController, playlistUri: String): List<SpotifyMusicMetadata>? = executeApiCall("Failed to get songs from playlist $playlistUri") {
 		if (webApi == null) {

--- a/app/src/main/java/me/hufman/androidautoidrive/music/spotify/SpotifyWebApi.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/music/spotify/SpotifyWebApi.kt
@@ -82,12 +82,14 @@ class SpotifyWebApi private constructor(val context: Context, val appSettings: M
 		var pagedSongs = webApi?.playlists?.getPlaylistTracks(playlistUri, 50, 0, null)
 		while(pagedSongs != null) {
 			pagedSongs.items.forEach { playlistTrack ->
-				if (playlistTrack.track?.asTrack != null) {
-					val track = playlistTrack.track?.asTrack
-					songs.add(createSpotifyMusicMetadataFromTrack(track!!, spotifyAppController))
-				} else if (playlistTrack.track?.asPodcastEpisodeTrack != null) {
-					val episodeTrack = playlistTrack.track?.asPodcastEpisodeTrack
-					songs.add(createSpotifyMusicMetadataFromPodcastEpisodeTrack(episodeTrack!!, spotifyAppController))
+				val track = playlistTrack.track?.asTrack
+				if (track != null) {
+					songs.add(createSpotifyMusicMetadataFromTrack(track, spotifyAppController))
+				}
+
+				val episodeTrack = playlistTrack.track?.asPodcastEpisodeTrack
+				if (episodeTrack != null) {
+					songs.add(createSpotifyMusicMetadataFromPodcastEpisodeTrack(episodeTrack, spotifyAppController))
 				}
 			}
 			pagedSongs = pagedSongs.getNext()

--- a/app/src/main/java/me/hufman/androidautoidrive/music/spotify/SpotifyWebApi.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/music/spotify/SpotifyWebApi.kt
@@ -81,15 +81,15 @@ class SpotifyWebApi private constructor(val context: Context, val appSettings: M
 		val songs: ArrayList<SpotifyMusicMetadata> = ArrayList()
 		var pagedSongs = webApi?.playlists?.getPlaylistTracks(playlistUri, 50, 0, null)
 		while(pagedSongs != null) {
-			songs.addAll(pagedSongs.items.map { playlistTrack ->
+			pagedSongs.items.forEach { playlistTrack ->
 				if (playlistTrack.track?.asTrack != null) {
 					val track = playlistTrack.track?.asTrack
-					createSpotifyMusicMetadataFromTrack(track!!, spotifyAppController)
-				} else {
+					songs.add(createSpotifyMusicMetadataFromTrack(track!!, spotifyAppController))
+				} else if (playlistTrack.track?.asPodcastEpisodeTrack != null) {
 					val episodeTrack = playlistTrack.track?.asPodcastEpisodeTrack
-					createSpotifyMusicMetadataFromPodcastEpisodeTrack(episodeTrack!!, spotifyAppController)
+					songs.add(createSpotifyMusicMetadataFromPodcastEpisodeTrack(episodeTrack!!, spotifyAppController))
 				}
-			})
+			}
 			pagedSongs = pagedSongs.getNext()
 		}
 

--- a/app/src/main/java/me/hufman/androidautoidrive/music/spotify/SpotifyWebApi.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/music/spotify/SpotifyWebApi.kt
@@ -70,6 +70,33 @@ class SpotifyWebApi private constructor(val context: Context, val appSettings: M
 	}
 
 	/**
+	 * Returns the songs from a specified playlist URI. This supports playlists that include both
+	 * songs and podcasts.
+	 */
+	suspend fun getPlaylistSongs(spotifyAppController: SpotifyAppController, playlistUri: String): List<SpotifyMusicMetadata>? = executeApiCall("Failed to get songs from playlist $playlistUri") {
+		if (webApi == null) {
+			return@executeApiCall emptyList()
+		}
+
+		val songs: ArrayList<SpotifyMusicMetadata> = ArrayList()
+		var pagedSongs = webApi?.playlists?.getPlaylistTracks(playlistUri, 50, 0, null)
+		while(pagedSongs != null) {
+			songs.addAll(pagedSongs.items.map { playlistTrack ->
+				if (playlistTrack.track?.asTrack != null) {
+					val track = playlistTrack.track?.asTrack
+					createSpotifyMusicMetadataFromTrack(track!!, spotifyAppController)
+				} else {
+					val episodeTrack = playlistTrack.track?.asPodcastEpisodeTrack
+					createSpotifyMusicMetadataFromPodcastEpisodeTrack(episodeTrack!!, spotifyAppController)
+				}
+			})
+			pagedSongs = pagedSongs.getNext()
+		}
+
+		return@executeApiCall songs
+	}
+
+	/**
 	 * Creates a private playlist with the provided name and optionally provided description. The
 	 * newly created playlist's [PlaylistUri] is returned.
 	 */
@@ -429,6 +456,14 @@ class SpotifyWebApi private constructor(val context: Context, val appSettings: M
 		val album = track.album
 		val coverArtUri = getCoverArtUri(album.images)
 		return SpotifyMusicMetadata(spotifyAppController, mediaId, mediaId.hashCode().toLong(), coverArtUri, artists, album.name, track.name)
+	}
+
+	private fun createSpotifyMusicMetadataFromPodcastEpisodeTrack(episode: PodcastEpisodeTrack, spotifyAppController: SpotifyAppController): SpotifyMusicMetadata {
+		val mediaId = episode.uri.uri
+		val artists = episode.artists.joinToString(", ") { it.name }
+		val album = episode.album
+		val coverArtUri = getCoverArtUri(album.images)
+		return SpotifyMusicMetadata(spotifyAppController, mediaId, mediaId.hashCode().toLong(), coverArtUri, artists, album.name, episode.name)
 	}
 
 	/**

--- a/app/src/test/java/me/hufman/androidautoidrive/music/SpotifyWebApiTest.kt
+++ b/app/src/test/java/me/hufman/androidautoidrive/music/SpotifyWebApiTest.kt
@@ -1593,6 +1593,259 @@ class SpotifyWebApiTest {
 		spotifyWebApi.setPlaylistImage(playlistId, coverArtImageData)
 	}
 
+	@Test
+	fun testGetPlaylistSongs_NullWebApi() = runBlocking {
+		FieldSetter.setField(spotifyWebApi, spotifyWebApi::class.java.getDeclaredField("webApi"), null)
+
+		val spotifyAppController: SpotifyAppController = mock()
+		val playlistUri = "playlistUri"
+		val songs = spotifyWebApi.getPlaylistSongs(spotifyAppController, playlistUri)
+
+		assertEquals(emptyList<SpotifyMusicMetadata>(), songs)
+	}
+
+	@Test
+	fun testGetPlaylistSongs_SongTrack() = runBlocking {
+		val uriId1 = "uriId1"
+		val trackName1 = "Track 1"
+		val artistName1 = "Artist 1"
+		val albumName1 = "Album 1"
+		val coverArtCode1 = "/coverArtCode1"
+
+		val uriId2 = "uriId2"
+		val trackName2 = "Track 2"
+		val artistName2 = "Artist 2"
+		val albumName2 = "Album 2"
+		val coverArtCode2 = "/coverArtCode2"
+
+		val playlistTracks = listOf(
+				createPlaylistTrack(uriId1, trackName1, artistName1, albumName1, coverArtCode1),
+				createPlaylistTrack(uriId2, trackName2, artistName2, albumName2, coverArtCode2)
+		)
+
+		val pagingObject: PagingObject<PlaylistTrack> = mock()
+		whenever(pagingObject.items).thenReturn(playlistTracks)
+
+		val playlistUri = "playlistUri"
+		val clientPlaylistApi: ClientPlaylistApi = mock()
+		whenever(clientPlaylistApi.getPlaylistTracks(playlistUri, 50, 0, null)).doAnswer { pagingObject }
+
+		val webApi: SpotifyClientApi = mock()
+		whenever(webApi.playlists).thenReturn(clientPlaylistApi)
+		FieldSetter.setField(spotifyWebApi, spotifyWebApi::class.java.getDeclaredField("webApi"), webApi)
+
+		val spotifyAppController: SpotifyAppController = mock()
+		val songs = spotifyWebApi.getPlaylistSongs(spotifyAppController, playlistUri)
+
+		assertNotNull(songs)
+		assertEquals(2, songs!!.size)
+
+		val metadata1 = createSpotifyMusicMetadata(spotifyAppController, "spotify:track:${uriId1}", coverArtCode1, artistName1, albumName1, trackName1, null, false, false)
+		assertEquals(metadata1, songs[0])
+
+		val metadata2 = createSpotifyMusicMetadata(spotifyAppController, "spotify:track:${uriId2}", coverArtCode2, artistName2, albumName2, trackName2, null, false, false)
+		assertEquals(metadata2, songs[1])
+	}
+
+	@Test
+	fun testGetPlaylistSongs_PodcastTrack() = runBlocking {
+		val uriId1 = "uriId1"
+		val trackName1 = "Track 1"
+		val artistName1 = "Artist 1"
+		val albumName1 = "Album 1"
+		val coverArtCode1 = "/coverArtCode1"
+
+		val uriId2 = "uriId2"
+		val trackName2 = "Track 2"
+		val artistName2 = "Artist 2"
+		val albumName2 = "Album 2"
+		val coverArtCode2 = "/coverArtCode2"
+
+		val playlistTracks = listOf(
+				createPlaylistPodcastTrack(uriId1, trackName1, artistName1, albumName1, coverArtCode1),
+				createPlaylistPodcastTrack(uriId2, trackName2, artistName2, albumName2, coverArtCode2)
+		)
+
+		val pagingObject: PagingObject<PlaylistTrack> = mock()
+		whenever(pagingObject.items).thenReturn(playlistTracks)
+
+		val playlistUri = "playlistUri"
+		val clientPlaylistApi: ClientPlaylistApi = mock()
+		whenever(clientPlaylistApi.getPlaylistTracks(playlistUri, 50, 0, null)).doAnswer { pagingObject }
+
+		val webApi: SpotifyClientApi = mock()
+		whenever(webApi.playlists).thenReturn(clientPlaylistApi)
+		FieldSetter.setField(spotifyWebApi, spotifyWebApi::class.java.getDeclaredField("webApi"), webApi)
+
+		val spotifyAppController: SpotifyAppController = mock()
+		val songs = spotifyWebApi.getPlaylistSongs(spotifyAppController, playlistUri)
+
+		assertNotNull(songs)
+		assertEquals(2, songs!!.size)
+
+		val metadata1 = createSpotifyMusicMetadata(spotifyAppController, "spotify:track:${uriId1}", coverArtCode1, artistName1, albumName1, trackName1, null, false, false)
+		assertEquals(metadata1, songs[0])
+
+		val metadata2 = createSpotifyMusicMetadata(spotifyAppController, "spotify:track:${uriId2}", coverArtCode2, artistName2, albumName2, trackName2, null, false, false)
+		assertEquals(metadata2, songs[1])
+	}
+
+	@Test
+	fun testGetPlaylistSongs_SongAndPodcastTracks() = runBlocking {
+		val uriId1 = "uriId1"
+		val trackName1 = "Track 1"
+		val artistName1 = "Artist 1"
+		val albumName1 = "Album 1"
+		val coverArtCode1 = "/coverArtCode1"
+
+		val uriId2 = "uriId2"
+		val trackName2 = "Track 2"
+		val artistName2 = "Artist 2"
+		val albumName2 = "Album 2"
+		val coverArtCode2 = "/coverArtCode2"
+
+		val playlistTracks = listOf(
+				createPlaylistPodcastTrack(uriId1, trackName1, artistName1, albumName1, coverArtCode1),
+				createPlaylistTrack(uriId2, trackName2, artistName2, albumName2, coverArtCode2)
+		)
+
+		val pagingObject: PagingObject<PlaylistTrack> = mock()
+		whenever(pagingObject.items).thenReturn(playlistTracks)
+
+		val playlistUri = "playlistUri"
+		val clientPlaylistApi: ClientPlaylistApi = mock()
+		whenever(clientPlaylistApi.getPlaylistTracks(playlistUri, 50, 0, null)).doAnswer { pagingObject }
+
+		val webApi: SpotifyClientApi = mock()
+		whenever(webApi.playlists).thenReturn(clientPlaylistApi)
+		FieldSetter.setField(spotifyWebApi, spotifyWebApi::class.java.getDeclaredField("webApi"), webApi)
+
+		val spotifyAppController: SpotifyAppController = mock()
+		val songs = spotifyWebApi.getPlaylistSongs(spotifyAppController, playlistUri)
+
+		assertNotNull(songs)
+		assertEquals(2, songs!!.size)
+
+		val metadata1 = createSpotifyMusicMetadata(spotifyAppController, "spotify:track:${uriId1}", coverArtCode1, artistName1, albumName1, trackName1, null, false, false)
+		assertEquals(metadata1, songs[0])
+
+		val metadata2 = createSpotifyMusicMetadata(spotifyAppController, "spotify:track:${uriId2}", coverArtCode2, artistName2, albumName2, trackName2, null, false, false)
+		assertEquals(metadata2, songs[1])
+	}
+
+	@Test
+	fun testGetPlaylistSongs_Pagination() = runBlocking {
+		val uriId1 = "uriId1"
+		val trackName1 = "Track 1"
+		val artistName1 = "Artist 1"
+		val albumName1 = "Album 1"
+		val coverArtCode1 = "/coverArtCode1"
+
+		val uriId2 = "uriId2"
+		val trackName2 = "Track 2"
+		val artistName2 = "Artist 2"
+		val albumName2 = "Album 2"
+		val coverArtCode2 = "/coverArtCode2"
+
+		val uriId3 = "uriId3"
+		val trackName3 = "Track 3"
+		val artistName3 = "Artist 3"
+		val albumName3 = "Album 3"
+		val coverArtCode3 = "/coverArtCode3"
+
+		val uriId4 = "uriId4"
+		val trackName4 = "Track 4"
+		val artistName4 = "Artist 4"
+		val albumName4 = "Album 4"
+		val coverArtCode4 = "/coverArtCode4"
+
+		val playlistTracks1 = listOf(
+				createPlaylistTrack(uriId1, trackName1, artistName1, albumName1, coverArtCode1),
+				createPlaylistPodcastTrack(uriId2, trackName2, artistName2, albumName2, coverArtCode2)
+		)
+
+		val playlistTracks2 = listOf(
+				createPlaylistPodcastTrack(uriId3, trackName3, artistName3, albumName3, coverArtCode3),
+				createPlaylistTrack(uriId4, trackName4, artistName4, albumName4, coverArtCode4)
+		)
+
+		val pagingObject2: PagingObject<PlaylistTrack> = mock()
+		whenever(pagingObject2.items).thenReturn(playlistTracks2)
+
+		val pagingObject1: PagingObject<PlaylistTrack> = mock()
+		whenever(pagingObject1.items).thenReturn(playlistTracks1)
+		whenever(pagingObject1.getNext()).thenReturn(pagingObject2)
+
+		val playlistUri = "playlistUri"
+		val clientPlaylistApi: ClientPlaylistApi = mock()
+		whenever(clientPlaylistApi.getPlaylistTracks(playlistUri, 50, 0, null)).doAnswer { pagingObject1 }
+
+		val webApi: SpotifyClientApi = mock()
+		whenever(webApi.playlists).thenReturn(clientPlaylistApi)
+		FieldSetter.setField(spotifyWebApi, spotifyWebApi::class.java.getDeclaredField("webApi"), webApi)
+
+		val spotifyAppController: SpotifyAppController = mock()
+		val songs = spotifyWebApi.getPlaylistSongs(spotifyAppController, playlistUri)
+
+		assertNotNull(songs)
+		assertEquals(4, songs!!.size)
+
+		val metadata1 = createSpotifyMusicMetadata(spotifyAppController, "spotify:track:${uriId1}", coverArtCode1, artistName1, albumName1, trackName1, null, false, false)
+		assertEquals(metadata1, songs[0])
+
+		val metadata2 = createSpotifyMusicMetadata(spotifyAppController, "spotify:track:${uriId2}", coverArtCode2, artistName2, albumName2, trackName2, null, false, false)
+		assertEquals(metadata2, songs[1])
+
+		val metadata3 = createSpotifyMusicMetadata(spotifyAppController, "spotify:track:${uriId3}", coverArtCode3, artistName3, albumName3, trackName3, null, false, false)
+		assertEquals(metadata3, songs[2])
+
+		val metadata4 = createSpotifyMusicMetadata(spotifyAppController, "spotify:track:${uriId4}", coverArtCode4, artistName4, albumName4, trackName4, null, false, false)
+		assertEquals(metadata4, songs[3])
+	}
+
+	@Test
+	fun testGetPlaylistSongs_AuthenticationException() = runBlocking {
+		val exception = SpotifyException.AuthenticationException("message")
+		val clientPlaylistApi: ClientPlaylistApi = mock()
+		val playlistUri = "playlistUri"
+		whenever(clientPlaylistApi.getPlaylistTracks(playlistUri, 50, 0, null)).doAnswer { throw exception }
+
+		val webApi: SpotifyClientApi = mock()
+		whenever(webApi.playlists).thenReturn(clientPlaylistApi)
+		FieldSetter.setField(spotifyWebApi, spotifyWebApi::class.java.getDeclaredField("webApi"), webApi)
+
+		doNothing().whenever(spotifyAuthStateManager).addAccessTokenAuthorizationException(exception)
+
+		val notificationManager: NotificationManager = mock()
+		whenever(context.getSystemService(NotificationManager::class.java)).thenReturn(notificationManager)
+
+		val spotifyAppController: SpotifyAppController = mock()
+		val songs = spotifyWebApi.getPlaylistSongs(spotifyAppController, playlistUri)
+
+		verify(notificationManager, never()).notify(any(), any())
+
+		assertEquals(null, songs)
+		val internalWebApi: SpotifyClientApi? = Whitebox.getInternalState(spotifyWebApi, "webApi")
+		assertNull(internalWebApi)
+	}
+
+	@Test
+	fun testGetPlaylistSongs_SpotifyException() = runBlocking {
+		val exception = SpotifyException.BadRequestException("message")
+		val clientPlaylistApi: ClientPlaylistApi = mock()
+		val playlistUri = "playlistUri"
+		whenever(clientPlaylistApi.getPlaylistTracks(playlistUri, 50, 0, null)).doAnswer { throw exception }
+
+		val webApi: SpotifyClientApi = mock()
+		whenever(webApi.playlists).thenReturn(clientPlaylistApi)
+		FieldSetter.setField(spotifyWebApi, spotifyWebApi::class.java.getDeclaredField("webApi"), webApi)
+
+		val spotifyAppController: SpotifyAppController = mock()
+		val songs = spotifyWebApi.getPlaylistSongs(spotifyAppController, playlistUri)
+
+		assertEquals(null, songs)
+	}
+
 	private fun createSpotifyMusicMetadata(spotifyAppController: SpotifyAppController, uriId: String, coverArtCode: String?, artistName: String?, albumName: String?, trackName: String, subtitle: String?, playable: Boolean, browseable: Boolean): SpotifyMusicMetadata {
 		val coverArtUri = if (coverArtCode != null) {
 			"spotify:image:${coverArtCode.drop(1)}"
@@ -1602,11 +1855,27 @@ class SpotifyWebApiTest {
 		return SpotifyMusicMetadata(spotifyAppController, uriId, uriId.hashCode().toLong(), coverArtUri, artistName, albumName, trackName, subtitle, playable, browseable)
 	}
 
+	private fun createPlaylistTrack(uriId: String, trackName: String, artistName: String, albumName: String, coverArtCode: String): PlaylistTrack {
+		val images = listOf(SpotifyImage(300, coverArtCode, 300))
+		val artists = listOf(SimpleArtist(emptyMap(), "href", "id", ArtistUri("artistUri"), artistName, "type"))
+		val album = SimpleAlbum("album", emptyList(), emptyMap(), "href", "id", AlbumUri("albumUri"), artists, images, albumName, "type", null, "1950", "year")
+		val track = Track(emptyMap(), emptyMap(), emptyList(), "", "", PlayableUri(uriId), album, artists, true, 1, 5, false, null, trackName, 1, null, 1, "")
+		return PlaylistTrack(null, null, null, false, track, null)
+	}
+
+	private fun createPlaylistPodcastTrack(uriId: String, trackName: String, artistName: String, albumName: String, coverArtCode: String): PlaylistTrack {
+		val images = listOf(SpotifyImage(300, coverArtCode, 300))
+		val artists = listOf(SimpleArtist(emptyMap(), "href", "id", ArtistUri("artistUri"), artistName, "type"))
+		val album = SimpleAlbum("album", emptyList(), emptyMap(), "href", "id", AlbumUri("albumUri"), artists, images, albumName, "type", null, "1950", "year")
+		val track = PodcastEpisodeTrack(album, artists, emptyList(), 1, 5, true, false, emptyMap(), emptyMap(), "", "", null, false, trackName, 1, "", null, 1,"type", PlayableUri(uriId), null)
+		return PlaylistTrack(null, null, null, false, track, null)
+	}
+
 	private fun createSavedTrack(uriId: String, trackName: String, artistName: String, albumName: String, coverArtCode: String, heightToMatch: Int = 300): SavedTrack {
 		val images = listOf(SpotifyImage(heightToMatch, coverArtCode, 300))
 		val artists = listOf(SimpleArtist(emptyMap(), "href", "id", ArtistUri("artistUri"), artistName, "type"))
 		val album = SimpleAlbum("album", emptyList(), emptyMap(), "href", "id", AlbumUri("albumUri"), artists, images, albumName, "type", null, "1950", "year")
-		return 	SavedTrack("value", Track(emptyMap(), emptyMap(), emptyList(), "", "", PlayableUri(uriId), album, artists, true, 1, 5, false, null, trackName, 1, null, 1, ""))
+		return SavedTrack("value", Track(emptyMap(), emptyMap(), emptyList(), "", "", PlayableUri(uriId), album, artists, true, 1, 5, false, null, trackName, 1, null, 1, ""))
 	}
 
 	private fun createSimpleAlbum(uriId: String, artistName: String, albumName: String, coverArtCode: String): SimpleAlbum {


### PR DESCRIPTION
I noticed that there is apparently a hard cap on the Spotify App Remote API of 350 tracks when getting the playlist tracks. To solve this I updated the logic to use the Spotify Web API to get tracks from a playlist in order to avoid that limit and now by default when playlists' tracks are retrieved the Spotify Web API will be the default way of getting those tracks. In the case the user doesn't have the Spotify Web API authenticated or the Web API call fails, the Spotify App Remote will be used as a fallback. The use of the Spotify Web API for retrieving playlist content will give us more flexibility in the future in how to construct the queue such as filtering out unavailable songs 