### PR TITLE
Adding text scrolling support

### DIFF
--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/TextScroller.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/TextScroller.kt
@@ -1,7 +1,7 @@
 package me.hufman.androidautoidrive.carapp.music
 
 /**
- * Handles the scrolling of text that is too long to fit on a line.
+ * Wrapper around a string that handles scrolling when it is too long to fit on a line.
  */
 class TextScroller(private val originalText: String, private val maxLineLength: Int) {
 	companion object {

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/TextScroller.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/TextScroller.kt
@@ -35,12 +35,11 @@ class TextScroller(private val originalText: String, private val maxLineLength: 
 		var displayText = originalText
 		val endIndex = maxLineLength + startIndex
 		if (scrollText) {
+			displayText = originalText.substring(startIndex, originalText.length)
 			if (endIndex <= originalText.length) {
-				displayText = originalText.substring(startIndex, endIndex)
 				startIndex += INDEX_JUMP_VALUE
 			} else {
 				scrollText = false
-				displayText = originalText.substring(startIndex, originalText.length)
 				startIndex = 0
 				previousTimestamp = System.currentTimeMillis()
 			}

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/TextScroller.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/TextScroller.kt
@@ -1,0 +1,46 @@
+package me.hufman.androidautoidrive.carapp.music
+
+/**
+ * Handles the scrolling of text that is too long to fit on a line.
+ */
+class TextScroller(private val originalText: String) {
+	companion object {
+		const val MAX_LINE_LENGTH = 33
+		const val SCROLL_COOLDOWN_SECONDS = 6
+		const val INDEX_JUMP_VALUE = 3
+	}
+
+	var scrollText: Boolean = false
+	var startIndex: Int = 0
+	var previousTimestamp: Long
+
+	init {
+		previousTimestamp = System.currentTimeMillis()
+	}
+
+	/**
+	 * Retrieves the current slice of the text to display. Every [SCROLL_COOLDOWN_SECONDS] the text
+	 * will be ready to start scrolling and making a call to this method will get the current state
+	 * of the text and shift the displayed slice at rate of [INDEX_JUMP_VALUE]. Once the slice reaches
+	 * the end of the original text, it will reset the slice back to the beginning and begin the
+	 * cooldown interval.
+	 */
+	fun getText(): String {
+		var displayText = originalText
+		val endIndex = MAX_LINE_LENGTH+startIndex
+		if (scrollText) {
+			if (endIndex <= originalText.length) {
+				displayText = originalText.substring(startIndex, endIndex)
+				startIndex += INDEX_JUMP_VALUE
+			} else {
+				scrollText = false
+				displayText = originalText.substring(startIndex, originalText.length)
+				startIndex = 0
+				previousTimestamp = System.currentTimeMillis()
+			}
+		} else if ((System.currentTimeMillis() - previousTimestamp) / 1000 >= SCROLL_COOLDOWN_SECONDS) {
+			scrollText = true
+		}
+		return displayText
+	}
+}

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/TextScroller.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/TextScroller.kt
@@ -3,9 +3,8 @@ package me.hufman.androidautoidrive.carapp.music
 /**
  * Handles the scrolling of text that is too long to fit on a line.
  */
-class TextScroller(private val originalText: String) {
+class TextScroller(private val originalText: String, private val maxLineLength: Int) {
 	companion object {
-		const val MAX_LINE_LENGTH = 33
 		const val SCROLL_COOLDOWN_SECONDS = 6
 		const val INDEX_JUMP_VALUE = 3
 	}
@@ -17,7 +16,7 @@ class TextScroller(private val originalText: String) {
 
 	init {
 		previousTimestamp = System.currentTimeMillis()
-		shouldScroll = originalText.length > MAX_LINE_LENGTH
+		shouldScroll = originalText.length > maxLineLength
 	}
 
 	/**
@@ -27,15 +26,14 @@ class TextScroller(private val originalText: String) {
 	 * the end of the original text, it will reset the slice back to the beginning and begin the
 	 * cooldown interval.
 	 *
-	 * If the original text is not long enough to need scrolling the original will
-	 * be returned.
+	 * If the original text is not long enough to need scrolling the original will be returned.
 	 */
 	fun getText(): String {
 		if (!shouldScroll) {
 			return originalText
 		}
 		var displayText = originalText
-		val endIndex = MAX_LINE_LENGTH+startIndex
+		val endIndex = maxLineLength + startIndex
 		if (scrollText) {
 			if (endIndex <= originalText.length) {
 				displayText = originalText.substring(startIndex, endIndex)

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/TextScroller.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/TextScroller.kt
@@ -10,12 +10,14 @@ class TextScroller(private val originalText: String) {
 		const val INDEX_JUMP_VALUE = 3
 	}
 
+	val shouldScroll: Boolean
 	var scrollText: Boolean = false
 	var startIndex: Int = 0
 	var previousTimestamp: Long
 
 	init {
 		previousTimestamp = System.currentTimeMillis()
+		shouldScroll = originalText.length > MAX_LINE_LENGTH
 	}
 
 	/**
@@ -24,8 +26,14 @@ class TextScroller(private val originalText: String) {
 	 * of the text and shift the displayed slice at rate of [INDEX_JUMP_VALUE]. Once the slice reaches
 	 * the end of the original text, it will reset the slice back to the beginning and begin the
 	 * cooldown interval.
+	 *
+	 * If the original text is not long enough to need scrolling the original will
+	 * be returned.
 	 */
 	fun getText(): String {
+		if (!shouldScroll) {
+			return originalText
+		}
 		var displayText = originalText
 		val endIndex = MAX_LINE_LENGTH+startIndex
 		if (scrollText) {

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/TextScroller.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/TextScroller.kt
@@ -5,14 +5,14 @@ package me.hufman.androidautoidrive.carapp.music
  */
 class TextScroller(private val originalText: String, private val maxLineLength: Int) {
 	companion object {
-		const val SCROLL_COOLDOWN_SECONDS = 6
+		const val SCROLL_COOLDOWN_SECONDS = 2
 		const val INDEX_JUMP_VALUE = 3
 	}
 
-	val shouldScroll: Boolean
-	var scrollText: Boolean = false
-	var startIndex: Int = 0
-	var previousTimestamp: Long
+	private val shouldScroll: Boolean
+	private var scrollText: Boolean = false
+	private var startIndex: Int = 0
+	private var previousTimestamp: Long
 
 	init {
 		previousTimestamp = System.currentTimeMillis()

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/PlaybackView.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/PlaybackView.kt
@@ -411,11 +411,9 @@ class PlaybackView(val state: RHMIState, val controller: MusicController, val ca
 			UnicodeCleaner.clean(song?.artist ?: "")
 		} else { L.MUSIC_DISCONNECTED }
 		artistTextScroller = TextScroller(artistTitle, MUSIC_METADATA_MAX_LINE_LENGTH)
-		artistModel.value = artistTextScroller.getText()
 
 		val albumTitle = UnicodeCleaner.clean(song?.album ?: "")
 		albumTextScroller = TextScroller(albumTitle, MUSIC_METADATA_MAX_LINE_LENGTH)
-		albumModel.value = albumTextScroller.getText()
 
 		val trackTitle = UnicodeCleaner.clean(song?.title ?: "")
 		val trackMaxLineLength = if (state is RHMIState.AudioHmiState) {
@@ -424,7 +422,8 @@ class PlaybackView(val state: RHMIState, val controller: MusicController, val ca
 			MUSIC_METADATA_MAX_LINE_LENGTH
 		}
 		trackTextScroller = TextScroller(trackTitle, trackMaxLineLength)
-		trackModel.value = trackTextScroller.getText()
+
+		redrawLongTitles()
 
 		val songCoverArt = song?.coverArt
 		if (songCoverArt != null) {

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/PlaybackView.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/PlaybackView.kt
@@ -23,6 +23,8 @@ import me.hufman.androidautoidrive.utils.Utils
 
 class PlaybackView(val state: RHMIState, val controller: MusicController, val carAppImages: Map<String, ByteArray>, val phoneAppResources: PhoneAppResources, val graphicsHelpers: GraphicsHelpers, val musicImageIDs: MusicImageIDs) {
 	companion object {
+		const val MUSIC_METADATA_MAX_LINE_LENGTH = 30
+		const val AUDIOSTATE_PLAYLIST_MAX_LINE_LENGTH = 28
 		const val INITIALIZATION_DEFERRED_TIMEOUT = 6000
 		const val POSITION_ACTION_DEBOUNCE = 500
 		fun fits(state: RHMIState): Boolean {
@@ -72,9 +74,9 @@ class PlaybackView(val state: RHMIState, val controller: MusicController, val ca
 	var skipNextEnabled: Boolean = true
 	var lastPositionActionTime: Long = 0
 
-	var artistTextScroller: TextScroller = TextScroller("")
-	var albumTextScroller: TextScroller = TextScroller("")
-	var trackTextScroller: TextScroller = TextScroller("")
+	var artistTextScroller: TextScroller = TextScroller("", 0)
+	var albumTextScroller: TextScroller = TextScroller("", 0)
+	var trackTextScroller: TextScroller = TextScroller("", 0)
 
 	init {
 		// discover widgets
@@ -408,16 +410,21 @@ class PlaybackView(val state: RHMIState, val controller: MusicController, val ca
 		val artistTitle = if (controller.isConnected()) {
 			UnicodeCleaner.clean(song?.artist ?: "")
 		} else { L.MUSIC_DISCONNECTED }
-		artistTextScroller = TextScroller(artistTitle)
-		artistModel.value = artistTitle
+		artistTextScroller = TextScroller(artistTitle, MUSIC_METADATA_MAX_LINE_LENGTH)
+		artistModel.value = artistTextScroller.getText()
 
 		val albumTitle = UnicodeCleaner.clean(song?.album ?: "")
-		albumTextScroller = TextScroller(albumTitle)
-		albumModel.value = albumTitle
+		albumTextScroller = TextScroller(albumTitle, MUSIC_METADATA_MAX_LINE_LENGTH)
+		albumModel.value = albumTextScroller.getText()
 
 		val trackTitle = UnicodeCleaner.clean(song?.title ?: "")
-		trackTextScroller = TextScroller(trackTitle)
-		trackModel.value = trackTitle
+		val trackMaxLineLength = if (state is RHMIState.AudioHmiState) {
+			AUDIOSTATE_PLAYLIST_MAX_LINE_LENGTH
+		} else {
+			MUSIC_METADATA_MAX_LINE_LENGTH
+		}
+		trackTextScroller = TextScroller(trackTitle, trackMaxLineLength)
+		trackModel.value = trackTextScroller.getText()
 
 		val songCoverArt = song?.coverArt
 		if (songCoverArt != null) {

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/PlaybackView.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/PlaybackView.kt
@@ -23,7 +23,6 @@ import me.hufman.androidautoidrive.utils.Utils
 
 class PlaybackView(val state: RHMIState, val controller: MusicController, val carAppImages: Map<String, ByteArray>, val phoneAppResources: PhoneAppResources, val graphicsHelpers: GraphicsHelpers, val musicImageIDs: MusicImageIDs) {
 	companion object {
-		const val MAX_LINE_LENGTH = 33
 		const val INITIALIZATION_DEFERRED_TIMEOUT = 6000
 		const val POSITION_ACTION_DEBOUNCE = 500
 		fun fits(state: RHMIState): Boolean {
@@ -73,13 +72,9 @@ class PlaybackView(val state: RHMIState, val controller: MusicController, val ca
 	var skipNextEnabled: Boolean = true
 	var lastPositionActionTime: Long = 0
 
-	var longArtistTitle = false
-	var longAlbumTitle = false
-	var longTrackTitle = false
-
-	lateinit var artistTextScroller: TextScroller
-	lateinit var albumTextScroller: TextScroller
-	lateinit var trackTextScroller: TextScroller
+	var artistTextScroller: TextScroller = TextScroller("")
+	var albumTextScroller: TextScroller = TextScroller("")
+	var trackTextScroller: TextScroller = TextScroller("")
 
 	init {
 		// discover widgets
@@ -392,17 +387,11 @@ class PlaybackView(val state: RHMIState, val controller: MusicController, val ca
 	 * Redraw long titles with current state of the text scrolling
 	 */
 	private fun redrawLongTitles() {
-		if (longArtistTitle) {
-			artistModel.value = artistTextScroller.getText()
-		}
-		if (longAlbumTitle) {
-			albumModel.value = albumTextScroller.getText()
-		}
-		if (longTrackTitle) {
-			val trackText = trackTextScroller.getText()
-			redrawAudiostatePlaylist(trackText)
-			trackModel.value = trackText
-		}
+		artistModel.value = artistTextScroller.getText()
+		albumModel.value = albumTextScroller.getText()
+		val trackText = trackTextScroller.getText()
+		redrawAudiostatePlaylist(trackText)
+		trackModel.value = trackText
 	}
 
 	private fun redrawApp() {
@@ -419,24 +408,15 @@ class PlaybackView(val state: RHMIState, val controller: MusicController, val ca
 		val artistTitle = if (controller.isConnected()) {
 			UnicodeCleaner.clean(song?.artist ?: "")
 		} else { L.MUSIC_DISCONNECTED }
-		longArtistTitle = artistTitle.length > MAX_LINE_LENGTH
-		if (longArtistTitle) {
-			artistTextScroller = TextScroller(artistTitle)
-		}
+		artistTextScroller = TextScroller(artistTitle)
 		artistModel.value = artistTitle
 
 		val albumTitle = UnicodeCleaner.clean(song?.album ?: "")
-		longAlbumTitle = albumTitle.length > MAX_LINE_LENGTH
-		if (longAlbumTitle) {
-			albumTextScroller = TextScroller(albumTitle)
-		}
+		albumTextScroller = TextScroller(albumTitle)
 		albumModel.value = albumTitle
 
 		val trackTitle = UnicodeCleaner.clean(song?.title ?: "")
-		longTrackTitle = trackTitle.length > MAX_LINE_LENGTH
-		if (longTrackTitle) {
-			trackTextScroller = TextScroller(trackTitle)
-		}
+		trackTextScroller = TextScroller(trackTitle)
 		trackModel.value = trackTitle
 
 		val songCoverArt = song?.coverArt

--- a/app/src/test/java/me/hufman/androidautoidrive/music/MusicAppTest.kt
+++ b/app/src/test/java/me/hufman/androidautoidrive/music/MusicAppTest.kt
@@ -699,12 +699,12 @@ class MusicAppTest {
 		assertEquals("Bitmap{320x320}", ((mockServer.data[IDs.COVERART_LARGE_MODEL] as BMWRemoting.RHMIResourceData).data as ByteArray).toString(Charset.defaultCharset()))
 		assertEquals("Bitmap{200x200}", ((mockServer.data[IDs.COVERART_SMALL_MODEL] as BMWRemoting.RHMIResourceData).data as ByteArray).toString(Charset.defaultCharset()))
 
-		// redraw should not replace metadata or coverart
+		// redraw should not replace coverart
 		mockServer.data.clear()
 		playbackView.redraw()
-		assertEquals(null, mockServer.data[IDs.ARTIST_LARGE_MODEL])
-		assertEquals(null, mockServer.data[IDs.ALBUM_LARGE_MODEL])
-		assertEquals(null, mockServer.data[IDs.TRACK_LARGE_MODEL])
+		assertEquals("Artist", mockServer.data[IDs.ARTIST_LARGE_MODEL])
+		assertEquals("Album", mockServer.data[IDs.ALBUM_LARGE_MODEL])
+		assertEquals("Title", mockServer.data[IDs.TRACK_LARGE_MODEL])
 		assertEquals(null, mockServer.data[IDs.COVERART_LARGE_MODEL])
 		assertEquals(null, mockServer.data[IDs.COVERART_SMALL_MODEL])
 

--- a/app/src/test/java/me/hufman/androidautoidrive/music/TextScrollerTest.kt
+++ b/app/src/test/java/me/hufman/androidautoidrive/music/TextScrollerTest.kt
@@ -1,0 +1,83 @@
+package me.hufman.androidautoidrive.music
+
+import com.nhaarman.mockito_kotlin.doAnswer
+import me.hufman.androidautoidrive.carapp.music.TextScroller
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.powermock.api.mockito.PowerMockito
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.modules.junit4.PowerMockRunner
+
+@RunWith(PowerMockRunner::class)
+@PrepareForTest(System::class, TextScroller::class)
+class TextScrollerTest {
+	val longText = "This is a long text segment that will scroll"
+
+	@Test
+	fun testGetText_ShouldNotScroll() {
+		val shortText = "some text"
+		PowerMockito.mockStatic(System::class.java)
+		PowerMockito.`when`(System.currentTimeMillis())
+				.doAnswer { 0L } // initialization
+
+		val textScroller = TextScroller(shortText, 30)
+
+		assertEquals(shortText, textScroller.getText())
+		assertEquals(shortText, textScroller.getText())
+	}
+
+	@Test
+	fun testGetText_TimeElapsedLessThanScrollCooldown() {
+		PowerMockito.mockStatic(System::class.java)
+		PowerMockito.`when`(System.currentTimeMillis())
+				.doAnswer { 0L } // initialization
+				.doAnswer { 1000L } // elapsed time
+		val textScroller = TextScroller(longText, 40)
+
+		assertEquals(longText, textScroller.getText())
+		assertFalse(textScroller.scrollText)
+	}
+
+	@Test
+	fun testGetText_TimeElapsedAfterScrollCooldown() {
+		PowerMockito.mockStatic(System::class.java)
+		PowerMockito.`when`(System.currentTimeMillis())
+				.doAnswer { 0L } // initialization
+				.doAnswer { 10000L } // elapsed time
+		val textScroller = TextScroller(longText, 40)
+
+		assertEquals(longText, textScroller.getText())
+		assertTrue(textScroller.scrollText)
+	}
+
+	@Test
+	fun testGetText_TextScroll_SliceHasNotReachedEndOfOriginalText() {
+		PowerMockito.mockStatic(System::class.java)
+		PowerMockito.`when`(System.currentTimeMillis())
+				.doAnswer { 0L } // initialization
+				.doAnswer { 10000L } // elapsed time
+		val textScroller = TextScroller(longText, 40)
+		textScroller.getText()
+
+		assertEquals(longText.substring(0, 40), textScroller.getText())
+		assertEquals(longText.substring(3, 43), textScroller.getText())
+	}
+
+	@Test
+	fun testGetText_TextScroll_SliceReachedEndOfOriginalText() {
+		PowerMockito.mockStatic(System::class.java)
+		PowerMockito.`when`(System.currentTimeMillis())
+				.doAnswer { 0L } // initialization
+				.doAnswer { 10000L } // elapsed time
+				.doAnswer { 20000L } // new previous timestamp
+				.doAnswer { 21000L } // elapsed time
+		val textScroller = TextScroller(longText, 40)
+		textScroller.getText()
+		textScroller.getText()
+		textScroller.getText()
+
+		assertEquals(longText.substring(6, longText.length), textScroller.getText())
+		assertEquals(longText, textScroller.getText())
+	}
+}

--- a/app/src/test/java/me/hufman/androidautoidrive/music/TextScrollerTest.kt
+++ b/app/src/test/java/me/hufman/androidautoidrive/music/TextScrollerTest.kt
@@ -33,10 +33,11 @@ class TextScrollerTest {
 		PowerMockito.`when`(System.currentTimeMillis())
 				.doAnswer { 0L } // initialization
 				.doAnswer { 1000L } // elapsed time
+				.doAnswer { 1001L } // elapsed time
 		val textScroller = TextScroller(longText, 40)
 
 		assertEquals(longText, textScroller.getText())
-		assertFalse(textScroller.scrollText)
+		assertEquals(longText, textScroller.getText())
 	}
 
 	@Test
@@ -45,10 +46,11 @@ class TextScrollerTest {
 		PowerMockito.`when`(System.currentTimeMillis())
 				.doAnswer { 0L } // initialization
 				.doAnswer { 10000L } // elapsed time
+				.doAnswer { 10001L } // elapsed time
 		val textScroller = TextScroller(longText, 40)
 
 		assertEquals(longText, textScroller.getText())
-		assertTrue(textScroller.scrollText)
+		assertEquals(longText.substring(0, 40), textScroller.getText())
 	}
 
 	@Test

--- a/app/src/test/java/me/hufman/androidautoidrive/music/TextScrollerTest.kt
+++ b/app/src/test/java/me/hufman/androidautoidrive/music/TextScrollerTest.kt
@@ -48,9 +48,11 @@ class TextScrollerTest {
 				.doAnswer { 10000L } // elapsed time
 				.doAnswer { 10001L } // elapsed time
 		val textScroller = TextScroller(longText, 40)
+		textScroller.getText()
 
 		assertEquals(longText, textScroller.getText())
-		assertEquals(longText.substring(0, 40), textScroller.getText())
+		assertEquals(longText.substring(3, longText.length), textScroller.getText())
+		assertEquals(longText.substring(6, longText.length), textScroller.getText())
 	}
 
 	@Test
@@ -62,8 +64,9 @@ class TextScrollerTest {
 		val textScroller = TextScroller(longText, 40)
 		textScroller.getText()
 
-		assertEquals(longText.substring(0, 40), textScroller.getText())
-		assertEquals(longText.substring(3, 43), textScroller.getText())
+		assertEquals(longText, textScroller.getText())
+		assertEquals(longText.substring(3, longText.length), textScroller.getText())
+		assertEquals(longText.substring(6, longText.length), textScroller.getText())
 	}
 
 	@Test


### PR DESCRIPTION
When text is too long to fit on a line, it is often truncated as the iDrive system has no built in text scrolling support. To get around this a TextScroller object has been implemented that wraps strings which will provide basic scrolling when those strings exceed a specified max line size. The scrolling logic works in the following fashion: 
1. The original text and max line length is provided to a TextScroller which handles the state of the string
2. The getText() method provides a way of retrieving the appropriate state of the string and is the way to advance the state of the TextScroller
3. If the string is less than the max line length then the original string will always be returned
4. After 6 seconds the string will begin a scroll routine, each call to getText() will return a slice of the string whose start and end indexes will increment by 3
5. Once the end index is greater than the length of the string, the last segment of the string will be returned from a call to getText()
6. The string returns to the beginning and a cooldown of 6 seconds is performed 

The TextScroller is currently applied to the artist, album, and track title strings in the PlaybackView. Below is a demo of what this looks like when each string is to long to be displayed in its entirety (note this is a contrived example for the sake of demoing this): 

![scrollingTextDemo](https://user-images.githubusercontent.com/11298573/169203461-7d134845-bb6e-4413-85b6-de4c14718b31.gif)

Implements https://github.com/BimmerGestalt/AAIdrive/issues/534